### PR TITLE
Id is not always required

### DIFF
--- a/lib/schema.json
+++ b/lib/schema.json
@@ -118,8 +118,7 @@
       "description": "\"Resource objects\" appear in a JSON API document to represent resources.",
       "type": "object",
       "required": [
-        "type",
-        "id"
+        "type"
       ],
       "properties": {
         "type": {


### PR DESCRIPTION
Fixes https://github.com/elliotttf/jsonapi-validator/issues/29

JSON API specification states that id is not required when the resource object originates at the client and represents a new resource to be created on the server.
